### PR TITLE
Added PHP 5.5 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "igor@wiedler.ch"
         }
     ],
+    "require": {
+        "php": ">=5.5.0"
+    },
     "autoload": {
         "files": ["reasoned.php"]
     }


### PR DESCRIPTION
The use of `yield` requires PHP 5.5
